### PR TITLE
Feature/event forms 22

### DIFF
--- a/_layouts/form.html
+++ b/_layouts/form.html
@@ -1,0 +1,53 @@
+---
+layout: default
+---
+
+{% include header.html %}
+<!--Header-->
+<main class="post_content">
+  <article class="post">
+    <header>
+      <div class="post_image">
+        <img src={{ page.img | prepend: site.baseurl}} alt="{{page.title}}">
+        {% unless page.submissions_open %}
+          <div class="ribbon large2"><span>Submissions Closed</span></div>
+        {% endif %}
+      </div>
+      <div class="post_description">
+        <h1 class="post_title">{{page.title}}</h1>
+      </div>
+    </header> <!-- End Header -->
+
+<!-- Section Post -->
+    <div class="entry_content">
+      <p><strong>{{page.intro}}</strong></p>
+      {{page.content | markdownify}}
+      {% if page.submissions_open %}
+        <div>{{ page.form }}</div>
+      {% else %}
+        <div>{{ page.closed_message }}</div>
+      {% endif %}
+    </div>
+
+
+    <div class="post_wrapper">
+      <footer class="post_footer cf">
+        <div class="post_share">
+          <span>Share:</span>
+          <a href="https://twitter.com/intent/tweet?text={{ page.title }}&url={{ site.url }}{{ page.url }}" title="Share on Twitter" rel="nofollow" target="_blank"><i class="fa fa-twitter" aria-hidden="true"></i></a>
+          <a href="https://facebook.com/sharer.php?u={{ site.url }}{{ page.url }}" title="Share on Facebook" rel="nofollow" target="_blank"><i class="fa fa-facebook" aria-hidden="true"></i></a>
+          <a href="https://plus.google.com/share?url={{ site.url }}{{ page.url }}" title="Share on Google+" rel="nofollow" target="_blank"><i class="fa fa-google" aria-hidden="true"></i></a>
+        </div>
+        <div class="post_tag">
+          <span>Tags:</span>
+          {% for tag in page.tags %}
+          <a class="tag">{{ tag }}</a>
+          {% endfor %}
+        </div>
+      </footer>
+    </div>
+  </article> <!-- End Section Post -->
+
+</main> <!-- End Section Post Content -->
+
+{% include footer.html %}

--- a/_pages/test.html
+++ b/_pages/test.html
@@ -5,4 +5,4 @@ sitemap: false
 ---
 
 
-{% include blog.html %}
+{% include form.html %}

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -152,3 +152,23 @@ collections:
         widget: "list"
         allow_add: false
         default: [Post]
+  - name: "forms"
+    label: "Forms"
+    folder: "_collections/_forms/"
+    create: true
+    slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    fields:
+      - {required: false, label: "Layout", name: "layout", widget: "hidden", default: "form"}
+      - {required: true, label: "Title", name: "title", widget: "string"}
+      - {required: false, label: "Introduction", name: "intro", widget: "text"}
+      - {required: false, label: "Body", name: "body", widget: "markdown"}
+      - {required: false, label: "Submissions Open", name: "submissions_open", widget: "boolean"}
+      - {required: false, label: "Submissions Closed Message", name: "closed_message", widget: "markdown"}
+      - {required: false, label: "Form", name: "form", widget: "code"}
+      - {required: false, label: "Short description (for Facebook)", name: "description", widget: "text"}
+      - {required: false, label: "Image", name: "img", widget: "image"}
+      - label: "Tags"
+        name: "tag"
+        widget: "list"
+        allow_add: false
+        default: [Form]


### PR DESCRIPTION
Add forms as a new collection type - aiming to allow embed forms as a new type of "post" so we can link to them internally instead.

The goal is to use Google Forms for submissions here, or any other for type (123forms, for example). By keeping it in house we can reduce the amount of website bouncing our users do.

These form pages also allow for RTE, so we can link directly to files such as the event registration form if users would prefer to use the PDF version instead of the site submission.